### PR TITLE
Install cython as a dependency

### DIFF
--- a/lbry_setup.sh
+++ b/lbry_setup.sh
@@ -13,7 +13,7 @@ exec 2> >(tee -a script_setup.log >&2)
 
 ROOT=.
 GIT_URL_ROOT="https://github.com/lbryio/"
-PACKAGES="git"
+PACKAGES="git cython"
 
 #install/update requirements
 if hash apt-get 2>/dev/null; then


### PR DESCRIPTION
The Cython package is required by the python console/log installation script (`setup.py install`).
Add the package to the main installation script.

(Related to issue #8)